### PR TITLE
Fixed issue #3:  Package.getActivationCommands is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 npm-debug.log
 node_modules
+
+.idea
+escape-utils.iml

--- a/lib/escape-utils.coffee
+++ b/lib/escape-utils.coffee
@@ -3,19 +3,18 @@ entities = new Entities()
 
 module.exports =
   activate: ->
-    atom.workspaceView.command "escape-utils:url-encode", => @transfromSel encodeURIComponent
-    atom.workspaceView.command "escape-utils:url-decode", => @transfromSel decodeURIComponent
-    atom.workspaceView.command "escape-utils:base64-encode", => @transfromSel @encodeBase64
-    atom.workspaceView.command "escape-utils:base64-decode", => @transfromSel @decodeBase64
-    atom.workspaceView.command "escape-utils:html-encode", => @transfromSel entities.encodeNonUTF
-    atom.workspaceView.command "escape-utils:html-encode-maintain-lines", => @transfromSel @encodeHtmlMaintainingLines
-    atom.workspaceView.command "escape-utils:html-decode", => @transfromSel entities.decode
+    atom.commands.add "atom-workspace", "escape-utils:url-encode": => @transfromSel encodeURIComponent
+    atom.commands.add "atom-workspace", "escape-utils:url-decode": => @transfromSel decodeURIComponent
+    atom.commands.add "atom-workspace", "escape-utils:base64-encode": => @transfromSel @encodeBase64
+    atom.commands.add "atom-workspace", "escape-utils:base64-decode": => @transfromSel @decodeBase64
+    atom.commands.add "atom-workspace", "escape-utils:html-encode": => @transfromSel entities.encodeNonUTF
+    atom.commands.add "atom-workspace", "escape-utils:html-encode-maintain-lines": => @transfromSel @encodeHtmlMaintainingLines
+    atom.commands.add "atom-workspace", "escape-utils:html-decode": => @transfromSel entities.decode
 
 
   transfromSel: (t) ->
     # This assumes the active pane item is an editor
-    editorView = atom.workspaceView.getActiveView()
-    editor = editorView?.getEditor()
+    editor = atom.workspace.getActiveTextEditor()
     if (editor?)
       selections = editor.getSelections()
       sel.insertText(t(sel.getText()), { "select": true}) for sel in selections

--- a/package.json
+++ b/package.json
@@ -17,16 +17,21 @@
     "html"
   ],
   "description": "Encode/decode URLs, Base65 or escape Html entites (future: JS/JSON, Base32/Base16, BinHex, Xml-Entities).",
-  "activationEvents": [
-    "escape-utils:url-encode",
-    "escape-utils:url-decode",
-    "escape-utils:base64-encode",
-    "escape-utils:base64-decode",
-    "escape-utils:html-encode",
-    "escape-utils:html-encode-maintain-lines",
-    "escape-utils:html-decode"
-  ],
-  "repository": "https://github.com/BrightIT/escape-utils",
+  "activationCommands": {
+    "atom-workspace": [
+        "escape-utils:url-encode",
+        "escape-utils:url-decode",
+        "escape-utils:base64-encode",
+        "escape-utils:base64-decode",
+        "escape-utils:html-encode",
+        "escape-utils:html-encode-maintain-lines",
+        "escape-utils:html-decode"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BrightIT/escape-utils"
+  },
   "license": "MIT",
   "engines": {
     "atom": ">0.100.0"

--- a/spec/escape-utils-spec.coffee
+++ b/spec/escape-utils-spec.coffee
@@ -1,4 +1,3 @@
-{WorkspaceView} = require 'atom'
 EscapeUtils = require '../lib/escape-utils'
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
@@ -10,25 +9,25 @@ describe "EscapeUtils", ->
   [activationPromise, editor] = []
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
+    atom.workspaceView = atom.views.getView(atom.workspace)
 
     waitsForPromise ->
-      atom.workspaceView.open().then (ed) ->
+      atom.workspace.open().then (ed) ->
         editor = ed
 
     activationPromise = atom.packages.activatePackage("escape-utils")
 
   trigger = (t, cb) ->
-    atom.workspaceView.trigger t
+    atom.commands.dispatch atom.workspaceView, t
     waitsForPromise -> activationPromise
     runs ->
       cb()
 
   describe "escape-utils:url-encode", ->
     it "still works even if the editor is not set", ->
-      atom.workspaceView.destroyActivePaneItem()
+      atom.workspace.destroyActivePaneItem()
       trigger 'escape-utils:url-encode', ->
-        expect(atom.workspaceView.getActiveView()).not.toBeDefined()
+        expect(atom.views.getView(atom.workspace.getActiveTextEditor())).not.toBeDefined()
 
     it "does nothing when nothing is selected", ->
       editor.setText "text with spaces\nanother line with special chars%=!+"


### PR DESCRIPTION
Fixed issue #3: Package.getActivationCommands is deprecated in Atom version 1.0.0
